### PR TITLE
Redesign filtered deck creator and add AGAIN re-queue behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,81 @@ Open [http://localhost:3000](http://localhost:3000).
 | DELETE | `/api/decks/{id}` | Delete deck |
 | POST | `/api/decks/{id}/reset` | Reset deck progress |
 
+## FSRS Algorithm & Card Lifecycle
+
+This app uses **FSRS-4.5** (Free Spaced Repetition Scheduler), a modern algorithm that replaced SM-2. The implementation lives in `src/lib/fsrs.ts`.
+
+### Card States
+
+Cards move through 4 states:
+
+```
+NEW ──▶ LEARNING ──▶ REVIEW ◀──▶ RELEARNING
+```
+
+- **New**: Never reviewed. First rating sets initial stability and difficulty.
+- **Learning**: Short intervals (1m / 5m / 10m). Graduates to Review on Good/Easy.
+- **Review**: Spaced intervals (days to months to years). Rating Again sends to Relearning.
+- **Relearning**: Back to short intervals until recovered, then returns to Review.
+
+### Ratings
+
+| Rating | Key | Effect |
+|--------|-----|--------|
+| **Again** | 1 | Complete blackout. Drops stability, increments lapse counter. |
+| **Hard** | 2 | Recalled with significant difficulty. Small stability increase with hard penalty. |
+| **Good** | 3 | Correct with some hesitation. Standard stability increase. |
+| **Easy** | 4 | Perfect recall. Large stability increase with easy bonus. |
+
+### Per-Card Metrics
+
+| Metric | Range | What It Means |
+|--------|-------|---------------|
+| **Stability** | 0.1+ | How long the memory lasts. Higher = longer intervals between reviews. |
+| **Difficulty** | 1-10 | How hard the card is *for you*. Derived from your ratings, not the content. Mean-reverts toward ~7.2 so it doesn't swing wildly. |
+| **Lapses** | 0+ | Number of times you forgot (rated Again from Review state). High lapses = "leech" card. |
+
+### How Intervals Are Calculated
+
+```
+interval = stability x (81/19) x (target_retention^(-2) - 1)
+```
+
+- **Target retention** is 90% — the algorithm schedules reviews so you have a 90% chance of remembering.
+- Higher stability = longer intervals.
+- Maximum interval is capped at 100 years.
+
+### How Difficulty Evolves
+
+Difficulty is set on your **first review** based on your rating:
+- Easy first rating → difficulty ~1.5
+- Again first rating → difficulty ~7.0
+
+After each review, difficulty adjusts based on your rating but **mean-reverts** toward the default (~7.2), so it converges over time rather than swinging wildly. Cards you consistently struggle with drift higher; cards you consistently nail drift lower.
+
+New cards have **no difficulty** — it's null until you first review them.
+
+### Filtered Decks (Cram Sessions)
+
+Filtered decks snapshot a set of cards into a fixed queue at creation time. Unlike regular reviews:
+
+- **No daily quotas** — it's a linear queue you work through.
+- **Cards rated Again get re-queued** — appended to the end so you keep seeing them until you get them right.
+- **Reviews still update SRS state** — stability, difficulty, and due dates are updated normally.
+- **Can be reset** to re-review the same set.
+
+Filter options: topics, subtopics, tags, state, importance, quality, difficulty range, and sort order (due date, most difficult, most lapses, random).
+
+### Regular Reviews vs Filtered Decks
+
+| Aspect | Regular Reviews | Filtered Decks |
+|--------|----------------|----------------|
+| Card selection | Dynamic — all cards due now | Fixed at creation |
+| Order | By due date | Configurable (due date, difficulty, lapses, random) |
+| Again behavior | Card gets short interval, appears when due | Card re-appended to end of queue |
+| Completion | Never — cards keep coming back | Done when queue is cleared |
+| Use case | Daily spaced repetition | Cramming, topic review, exam prep |
+
 ## Tech Stack
 
 - **Frontend**: Next.js 14, React, Tailwind CSS

--- a/src/app/api/decks/[id]/next/route.ts
+++ b/src/app/api/decks/[id]/next/route.ts
@@ -83,6 +83,8 @@ export async function GET(
 /**
  * POST /api/decks/[id]/next
  * Advance to the next card in the deck (called after review)
+ * If rating is AGAIN (1), re-append the card to the end of the queue
+ * so the user sees it again before the deck completes.
  */
 export async function POST(
   request: Request,
@@ -91,6 +93,15 @@ export async function POST(
   try {
     const { id: deckId } = params
     const supabase = createServiceClient()
+
+    // Parse optional rating from body
+    let rating: number | null = null
+    try {
+      const body = await request.json()
+      rating = body.rating ?? null
+    } catch {
+      // No body or invalid JSON — that's fine, just advance
+    }
 
     // Get current deck state
     const { data: deck, error: deckError } = await supabase
@@ -103,16 +114,31 @@ export async function POST(
       return NextResponse.json({ error: 'Deck not found' }, { status: 404 })
     }
 
-    const newPosition = deck.current_position + 1
-    const completed = newPosition >= deck.card_queue.length
+    let cardQueue = [...deck.card_queue]
 
-    // Update deck position
+    // If rated AGAIN, re-append the current card to the end of the queue
+    if (rating === 1) {
+      const currentCardId = cardQueue[deck.current_position]
+      if (currentCardId) {
+        cardQueue.push(currentCardId)
+      }
+    }
+
+    const newPosition = deck.current_position + 1
+    const completed = newPosition >= cardQueue.length
+
+    // Update deck position (and queue if it grew)
+    const updateData: Record<string, unknown> = {
+      current_position: newPosition,
+      completed,
+    }
+    if (rating === 1) {
+      updateData.card_queue = cardQueue
+    }
+
     const { error: updateError } = await supabase
       .from('filtered_decks')
-      .update({
-        current_position: newPosition,
-        completed,
-      })
+      .update(updateData)
       .eq('deck_id', deckId)
 
     if (updateError) {

--- a/src/app/api/decks/route.ts
+++ b/src/app/api/decks/route.ts
@@ -57,6 +57,10 @@ export async function POST(request: Request) {
       filterTags = [],
       filterStates = [],
       filterImportance = [],
+      filterQuality = [],
+      filterDifficultyMin,
+      filterDifficultyMax,
+      sortOrder = 'due_date',
       maxCards,
     } = body
 
@@ -72,7 +76,7 @@ export async function POST(request: Request) {
     // Build query to get matching cards
     let query = supabase
       .from('cards')
-      .select('card_id')
+      .select('card_id, difficulty')
       .neq('state', 'suspended')
 
     // Apply filters
@@ -85,17 +89,39 @@ export async function POST(request: Request) {
     if (filterStates.length > 0) {
       query = query.in('state', filterStates)
     }
-    // Tags filter requires contains check
     if (filterTags.length > 0) {
       query = query.overlaps('tags', filterTags)
     }
-    // Importance filter (core/supporting)
     if (filterImportance.length > 0) {
       query = query.in('importance', filterImportance)
     }
+    if (filterQuality.length > 0) {
+      query = query.in('quality', filterQuality)
+    }
+    // Difficulty range (only applies to reviewed cards with difficulty > 0)
+    if (filterDifficultyMin != null) {
+      query = query.gte('difficulty', filterDifficultyMin)
+    }
+    if (filterDifficultyMax != null) {
+      query = query.lte('difficulty', filterDifficultyMax)
+    }
 
-    // Order by due date (most overdue first)
-    query = query.order('due_date', { ascending: true })
+    // Apply sort order
+    switch (sortOrder) {
+      case 'difficulty':
+        query = query.order('difficulty', { ascending: false })
+        break
+      case 'lapses':
+        query = query.order('lapses', { ascending: false })
+        break
+      case 'random':
+        // Fetch all, shuffle client-side
+        break
+      case 'due_date':
+      default:
+        query = query.order('due_date', { ascending: true })
+        break
+    }
 
     // Apply limit
     if (maxCards && maxCards > 0) {
@@ -109,7 +135,19 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: cardsError.message }, { status: 500 })
     }
 
-    const cardQueue = cards?.map(c => c.card_id) || []
+    let cardQueue = cards?.map(c => c.card_id) || []
+
+    // Shuffle for random sort order
+    if (sortOrder === 'random') {
+      for (let i = cardQueue.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1))
+        ;[cardQueue[i], cardQueue[j]] = [cardQueue[j], cardQueue[i]]
+      }
+      // Apply max cards after shuffle
+      if (maxCards && maxCards > 0) {
+        cardQueue = cardQueue.slice(0, maxCards)
+      }
+    }
 
     if (cardQueue.length === 0) {
       return NextResponse.json(
@@ -126,9 +164,14 @@ export async function POST(request: Request) {
         deck_id: deckId,
         name,
         filter_topics: filterTopics,
+        filter_subtopics: filterSubtopics,
         filter_tags: filterTags,
         filter_states: filterStates,
         filter_importance: filterImportance,
+        filter_quality: filterQuality,
+        filter_difficulty_min: filterDifficultyMin ?? null,
+        filter_difficulty_max: filterDifficultyMax ?? null,
+        sort_order: sortOrder,
         max_cards: maxCards || null,
         card_queue: cardQueue,
         current_position: 0,

--- a/src/app/api/topics/route.ts
+++ b/src/app/api/topics/route.ts
@@ -6,20 +6,20 @@ export const dynamic = 'force-dynamic'
 
 /**
  * GET /api/topics
- * Get all unique topics for deck filter UI
+ * Get all unique topics, subtopics (hierarchical), tags, and quality values
  */
 export async function GET() {
   try {
     const supabase = createServiceClient()
 
-    // Get distinct topics and subtopics
-    const { data: topicData, error: topicError } = await supabase
+    // Get topics, subtopics, and quality in one query
+    const { data: cardData, error: cardError } = await supabase
       .from('cards')
-      .select('topic, subtopic')
+      .select('topic, subtopic, quality')
 
-    if (topicError) {
-      console.error('Error fetching topics:', topicError)
-      return NextResponse.json({ error: topicError.message }, { status: 500 })
+    if (cardError) {
+      console.error('Error fetching card data:', cardError)
+      return NextResponse.json({ error: cardError.message }, { status: 500 })
     }
 
     // Get distinct tags
@@ -32,15 +32,42 @@ export async function GET() {
       return NextResponse.json({ error: tagError.message }, { status: 500 })
     }
 
-    // Extract unique values
-    const topics = Array.from(new Set(topicData?.map(t => t.topic).filter(Boolean)))
-    const subtopics = Array.from(new Set(topicData?.map(t => t.subtopic).filter(Boolean)))
-    const tags = Array.from(new Set(tagData?.flatMap(t => t.tags || []).filter(Boolean)))
+    // Build hierarchical topic tree: { topic: subtopic[] }
+    const topicTree: Record<string, string[]> = {}
+    for (const row of cardData || []) {
+      if (!row.topic) continue
+      if (!topicTree[row.topic]) {
+        topicTree[row.topic] = []
+      }
+      if (row.subtopic && !topicTree[row.topic].includes(row.subtopic)) {
+        topicTree[row.topic].push(row.subtopic)
+      }
+    }
+    // Sort subtopics within each topic
+    for (const topic of Object.keys(topicTree)) {
+      topicTree[topic].sort()
+    }
+
+    // Extract flat lists for backwards compatibility
+    const topics = Object.keys(topicTree).sort()
+    const subtopics = Array.from(
+      new Set(cardData?.map(t => t.subtopic).filter(Boolean))
+    ).sort()
+
+    const tags = Array.from(
+      new Set(tagData?.flatMap(t => t.tags || []).filter(Boolean))
+    ).sort()
+
+    const quality = Array.from(
+      new Set(cardData?.map(t => t.quality).filter(Boolean))
+    ).sort()
 
     return NextResponse.json({
-      topics: topics.sort(),
-      subtopics: subtopics.sort(),
-      tags: tags.sort(),
+      topicTree,
+      topics,
+      subtopics,
+      tags,
+      quality,
       states: ['new', 'learning', 'review', 'relearning'],
       importance: ['core', 'supporting'],
     })

--- a/src/app/decks/[id]/page.tsx
+++ b/src/app/decks/[id]/page.tsx
@@ -93,9 +93,11 @@ export default function DeckReviewPage() {
         }),
       })
 
-      // Advance deck position
+      // Advance deck position (pass rating so AGAIN cards get re-queued)
       await fetch(`/api/decks/${deckId}/next`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating }),
       })
 
       // Fetch next card

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import Link from 'next/link'
 
 interface Deck {
   deck_id: string
   name: string
   filter_topics: string[]
+  filter_subtopics: string[]
   filter_tags: string[]
   filter_states: string[]
   filter_importance: string[]
+  filter_quality: string[]
+  sort_order: string
   totalCards: number
   progress: number
   progressPercent: number
@@ -17,9 +20,11 @@ interface Deck {
 }
 
 interface FilterOptions {
+  topicTree: Record<string, string[]>
   topics: string[]
   subtopics: string[]
   tags: string[]
+  quality: string[]
   states: string[]
   importance: string[]
 }
@@ -27,24 +32,50 @@ interface FilterOptions {
 export default function DecksPage() {
   const [decks, setDecks] = useState<Deck[]>([])
   const [filterOptions, setFilterOptions] = useState<FilterOptions>({
+    topicTree: {},
     topics: [],
     subtopics: [],
     tags: [],
+    quality: [],
     states: [],
     importance: [],
   })
   const [isLoading, setIsLoading] = useState(true)
   const [showCreateModal, setShowCreateModal] = useState(false)
 
-  // Form state for new deck
+  // Form state
   const [newDeckName, setNewDeckName] = useState('')
   const [selectedTopics, setSelectedTopics] = useState<string[]>([])
   const [selectedSubtopics, setSelectedSubtopics] = useState<string[]>([])
   const [selectedTags, setSelectedTags] = useState<string[]>([])
   const [selectedStates, setSelectedStates] = useState<string[]>([])
   const [selectedImportance, setSelectedImportance] = useState<string[]>([])
+  const [selectedQuality, setSelectedQuality] = useState<string[]>([])
+  const [difficultyMin, setDifficultyMin] = useState<number | ''>('')
+  const [difficultyMax, setDifficultyMax] = useState<number | ''>('')
+  const [sortOrder, setSortOrder] = useState('due_date')
   const [maxCards, setMaxCards] = useState<number | ''>('')
   const [isCreating, setIsCreating] = useState(false)
+
+  // Topic accordion state
+  const [expandedTopics, setExpandedTopics] = useState<string[]>([])
+
+  // Tag search state
+  const [tagSearch, setTagSearch] = useState('')
+  const [tagDropdownOpen, setTagDropdownOpen] = useState(false)
+  const tagInputRef = useRef<HTMLInputElement>(null)
+  const tagContainerRef = useRef<HTMLDivElement>(null)
+
+  // Close tag dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (tagContainerRef.current && !tagContainerRef.current.contains(e.target as Node)) {
+        setTagDropdownOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
 
   // Fetch decks and filter options
   useEffect(() => {
@@ -60,7 +91,15 @@ export default function DecksPage() {
         const topicsData = await topicsRes.json()
 
         setDecks(decksData.decks || [])
-        setFilterOptions(topicsData)
+        setFilterOptions({
+          topicTree: topicsData.topicTree || {},
+          topics: topicsData.topics || [],
+          subtopics: topicsData.subtopics || [],
+          tags: topicsData.tags || [],
+          quality: topicsData.quality || [],
+          states: topicsData.states || [],
+          importance: topicsData.importance || [],
+        })
       } catch (err) {
         console.error('Error fetching data:', err)
       } finally {
@@ -88,6 +127,10 @@ export default function DecksPage() {
           filterTags: selectedTags,
           filterStates: selectedStates,
           filterImportance: selectedImportance,
+          filterQuality: selectedQuality,
+          filterDifficultyMin: difficultyMin || null,
+          filterDifficultyMax: difficultyMax || null,
+          sortOrder,
           maxCards: maxCards || null,
         }),
       })
@@ -109,7 +152,6 @@ export default function DecksPage() {
     }
   }
 
-  // Reset form
   const resetForm = () => {
     setNewDeckName('')
     setSelectedTopics([])
@@ -117,13 +159,17 @@ export default function DecksPage() {
     setSelectedTags([])
     setSelectedStates([])
     setSelectedImportance([])
+    setSelectedQuality([])
+    setDifficultyMin('')
+    setDifficultyMax('')
+    setSortOrder('due_date')
     setMaxCards('')
+    setExpandedTopics([])
+    setTagSearch('')
   }
 
-  // Delete deck
   const handleDeleteDeck = async (deckId: string) => {
     if (!confirm('Delete this deck?')) return
-
     try {
       await fetch(`/api/decks/${deckId}`, { method: 'DELETE' })
       setDecks(decks.filter(d => d.deck_id !== deckId))
@@ -132,7 +178,6 @@ export default function DecksPage() {
     }
   }
 
-  // Reset deck
   const handleResetDeck = async (deckId: string) => {
     try {
       await fetch(`/api/decks/${deckId}/reset`, { method: 'POST' })
@@ -146,7 +191,6 @@ export default function DecksPage() {
     }
   }
 
-  // Toggle selection in multi-select
   const toggleSelection = (
     value: string,
     selected: string[],
@@ -158,6 +202,76 @@ export default function DecksPage() {
       setSelected([...selected, value])
     }
   }
+
+  // Topic accordion helpers
+  const toggleTopicExpanded = (topic: string) => {
+    setExpandedTopics(prev =>
+      prev.includes(topic)
+        ? prev.filter(t => t !== topic)
+        : [...prev, topic]
+    )
+  }
+
+  const isTopicFullySelected = (topic: string) => {
+    const subtopics = filterOptions.topicTree[topic] || []
+    return subtopics.length > 0 && subtopics.every(st => selectedSubtopics.includes(st))
+  }
+
+  const isTopicPartiallySelected = (topic: string) => {
+    const subtopics = filterOptions.topicTree[topic] || []
+    const someSelected = subtopics.some(st => selectedSubtopics.includes(st))
+    return someSelected && !isTopicFullySelected(topic)
+  }
+
+  const toggleTopicSelection = (topic: string) => {
+    const subtopics = filterOptions.topicTree[topic] || []
+
+    if (isTopicFullySelected(topic)) {
+      // Deselect topic and all its subtopics
+      setSelectedTopics(prev => prev.filter(t => t !== topic))
+      setSelectedSubtopics(prev => prev.filter(st => !subtopics.includes(st)))
+    } else {
+      // Select topic and all its subtopics
+      if (!selectedTopics.includes(topic)) {
+        setSelectedTopics(prev => [...prev, topic])
+      }
+      setSelectedSubtopics(prev => {
+        const newSubs = [...prev]
+        for (const st of subtopics) {
+          if (!newSubs.includes(st)) newSubs.push(st)
+        }
+        return newSubs
+      })
+    }
+  }
+
+  const toggleSubtopicSelection = (topic: string, subtopic: string) => {
+    const subtopics = filterOptions.topicTree[topic] || []
+
+    if (selectedSubtopics.includes(subtopic)) {
+      // Deselect subtopic
+      const newSubs = selectedSubtopics.filter(st => st !== subtopic)
+      setSelectedSubtopics(newSubs)
+      // If no subtopics of this topic remain, deselect the topic too
+      const remainingForTopic = newSubs.filter(st => subtopics.includes(st))
+      if (remainingForTopic.length === 0) {
+        setSelectedTopics(prev => prev.filter(t => t !== topic))
+      }
+    } else {
+      // Select subtopic and ensure parent topic is selected
+      setSelectedSubtopics(prev => [...prev, subtopic])
+      if (!selectedTopics.includes(topic)) {
+        setSelectedTopics(prev => [...prev, topic])
+      }
+    }
+  }
+
+  // Tag search helpers
+  const filteredTags = filterOptions.tags.filter(
+    tag =>
+      !selectedTags.includes(tag) &&
+      tag.toLowerCase().includes(tagSearch.toLowerCase())
+  )
 
   if (isLoading) {
     return (
@@ -173,7 +287,7 @@ export default function DecksPage() {
       <div className="flex justify-between items-center mb-6">
         <div>
           <Link href="/" className="text-gray-400 hover:text-white text-sm">
-            ← Home
+            &larr; Home
           </Link>
           <h1 className="text-2xl font-bold mt-2">Filtered Decks</h1>
         </div>
@@ -194,16 +308,13 @@ export default function DecksPage() {
       ) : (
         <div className="space-y-4">
           {decks.map(deck => (
-            <div
-              key={deck.deck_id}
-              className="bg-dark-card rounded-lg p-4"
-            >
+            <div key={deck.deck_id} className="bg-dark-card rounded-lg p-4">
               <div className="flex justify-between items-start mb-2">
                 <div>
                   <h3 className="font-medium text-lg">{deck.name}</h3>
                   <div className="text-sm text-gray-400">
                     {deck.progress} / {deck.totalCards} cards
-                    {deck.completed && ' • Completed ✓'}
+                    {deck.completed && ' \u2022 Completed \u2713'}
                   </div>
                 </div>
                 <div className="flex gap-2">
@@ -228,7 +339,6 @@ export default function DecksPage() {
                 </div>
               </div>
 
-              {/* Progress bar */}
               <div className="progress-bar">
                 <div
                   className="progress-fill"
@@ -236,29 +346,40 @@ export default function DecksPage() {
                 />
               </div>
 
-              {/* Filter tags */}
-              {(deck.filter_topics.length > 0 || deck.filter_tags.length > 0 || deck.filter_states.length > 0 || (deck.filter_importance && deck.filter_importance.length > 0)) && (
+              {/* Filter tags display */}
+              {(
+                (deck.filter_topics || []).length > 0 ||
+                (deck.filter_tags || []).length > 0 ||
+                (deck.filter_states || []).length > 0 ||
+                (deck.filter_importance || []).length > 0 ||
+                (deck.filter_quality || []).length > 0
+              ) && (
                 <div className="flex flex-wrap gap-1 mt-2">
-                  {deck.filter_topics.map(t => (
-                    <span key={t} className="text-xs bg-accent-green/30 px-2 py-0.5 rounded">
-                      {t}
-                    </span>
+                  {(deck.filter_topics || []).map(t => (
+                    <span key={t} className="text-xs bg-accent-green/30 px-2 py-0.5 rounded">{t}</span>
                   ))}
-                  {deck.filter_tags.map(t => (
-                    <span key={t} className="text-xs bg-dark-accent px-2 py-0.5 rounded">
-                      #{t}
-                    </span>
+                  {(deck.filter_subtopics || []).map(t => (
+                    <span key={t} className="text-xs bg-accent-green/20 px-2 py-0.5 rounded">{t}</span>
                   ))}
-                  {deck.filter_states.map(s => (
-                    <span key={s} className="text-xs bg-gray-600/30 px-2 py-0.5 rounded">
-                      {s}
-                    </span>
+                  {(deck.filter_tags || []).map(t => (
+                    <span key={t} className="text-xs bg-dark-accent px-2 py-0.5 rounded">#{t}</span>
+                  ))}
+                  {(deck.filter_states || []).map(s => (
+                    <span key={s} className="text-xs bg-gray-600/30 px-2 py-0.5 rounded">{s}</span>
                   ))}
                   {(deck.filter_importance || []).map(imp => (
                     <span key={imp} className={`text-xs px-2 py-0.5 rounded ${imp === 'core' ? 'bg-accent-green/30' : 'bg-gray-500/30'}`}>
-                      {imp === 'core' ? '⭐ core' : 'supporting'}
+                      {imp === 'core' ? 'core' : 'supporting'}
                     </span>
                   ))}
+                  {(deck.filter_quality || []).map(q => (
+                    <span key={q} className="text-xs bg-blue-500/30 px-2 py-0.5 rounded">Quality {q}</span>
+                  ))}
+                  {deck.sort_order && deck.sort_order !== 'due_date' && (
+                    <span className="text-xs bg-gray-600/30 px-2 py-0.5 rounded">
+                      Sort: {deck.sort_order}
+                    </span>
+                  )}
                 </div>
               )}
             </div>
@@ -269,15 +390,13 @@ export default function DecksPage() {
       {/* Create Modal */}
       {showCreateModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-dark-card rounded-xl p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
+          <div className="bg-dark-card rounded-xl p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto">
             <h2 className="text-xl font-bold mb-4">Create Filtered Deck</h2>
 
-            <form onSubmit={handleCreateDeck} className="space-y-4">
-              {/* Name */}
+            <form onSubmit={handleCreateDeck} className="space-y-5">
+              {/* Deck Name */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
-                  Deck Name
-                </label>
+                <label className="block text-sm text-gray-400 mb-1">Deck Name</label>
                 <input
                   type="text"
                   value={newDeckName}
@@ -288,93 +407,166 @@ export default function DecksPage() {
                 />
               </div>
 
-              {/* Topics */}
-              {filterOptions.topics.length > 0 && (
+              {/* ── Topics & Subtopics Accordion ── */}
+              {Object.keys(filterOptions.topicTree).length > 0 && (
                 <div>
-                  <label className="block text-sm text-gray-400 mb-1">
-                    Filter by Topics
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {filterOptions.topics.map(topic => (
-                      <button
-                        key={topic}
-                        type="button"
-                        onClick={() => toggleSelection(topic, selectedTopics, setSelectedTopics)}
-                        className={`px-3 py-1 rounded-full text-sm ${
-                          selectedTopics.includes(topic)
-                            ? 'bg-accent-green text-gray-900'
-                            : 'bg-gray-700 hover:bg-gray-600'
-                        }`}
-                      >
-                        {topic}
-                      </button>
+                  <label className="block text-sm text-gray-400 mb-2">Topics &amp; Subtopics</label>
+                  <div className="border border-gray-600 rounded-lg overflow-hidden">
+                    {Object.entries(filterOptions.topicTree).map(([topic, subtopics]) => (
+                      <div key={topic} className="border-b border-gray-700 last:border-b-0">
+                        {/* Topic row */}
+                        <div className="flex items-center gap-2 px-3 py-2 hover:bg-dark-accent/30">
+                          {/* Expand/collapse button */}
+                          <button
+                            type="button"
+                            onClick={() => toggleTopicExpanded(topic)}
+                            className="text-gray-400 hover:text-white w-5 text-center flex-shrink-0"
+                          >
+                            {expandedTopics.includes(topic) ? '\u25BC' : '\u25B6'}
+                          </button>
+
+                          {/* Topic checkbox */}
+                          <label className="flex items-center gap-2 flex-1 cursor-pointer select-none">
+                            <input
+                              type="checkbox"
+                              checked={isTopicFullySelected(topic)}
+                              ref={el => {
+                                if (el) el.indeterminate = isTopicPartiallySelected(topic)
+                              }}
+                              onChange={() => toggleTopicSelection(topic)}
+                              className="w-4 h-4 rounded accent-[#8AC926]"
+                            />
+                            <span className="font-medium">{topic}</span>
+                            <span className="text-xs text-gray-500">
+                              ({subtopics.length} subtopic{subtopics.length !== 1 ? 's' : ''})
+                            </span>
+                          </label>
+                        </div>
+
+                        {/* Subtopics (expanded) */}
+                        {expandedTopics.includes(topic) && subtopics.length > 0 && (
+                          <div className="bg-dark-bg/50 pl-10 pr-3 py-1">
+                            {subtopics.map(subtopic => (
+                              <label
+                                key={subtopic}
+                                className="flex items-center gap-2 py-1.5 cursor-pointer select-none hover:text-white text-gray-300"
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={selectedSubtopics.includes(subtopic)}
+                                  onChange={() => toggleSubtopicSelection(topic, subtopic)}
+                                  className="w-4 h-4 rounded accent-[#8AC926]"
+                                />
+                                <span className="text-sm">{subtopic}</span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                      </div>
                     ))}
                   </div>
+                  {/* Selected summary */}
+                  {selectedSubtopics.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mt-2">
+                      {selectedSubtopics.map(st => (
+                        <span
+                          key={st}
+                          className="text-xs bg-accent-green/20 text-accent-green px-2 py-0.5 rounded-full flex items-center gap-1"
+                        >
+                          {st}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              // Find parent topic
+                              const parentTopic = Object.entries(filterOptions.topicTree)
+                                .find(([, subs]) => subs.includes(st))?.[0]
+                              if (parentTopic) toggleSubtopicSelection(parentTopic, st)
+                            }}
+                            className="hover:text-white"
+                          >
+                            &times;
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 
-              {/* Subtopics */}
-              {filterOptions.subtopics.length > 0 && (
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">
-                    Filter by Subtopics
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {filterOptions.subtopics.map(subtopic => (
-                      <button
-                        key={subtopic}
-                        type="button"
-                        onClick={() => toggleSelection(subtopic, selectedSubtopics, setSelectedSubtopics)}
-                        className={`px-3 py-1 rounded-full text-sm ${
-                          selectedSubtopics.includes(subtopic)
-                            ? 'bg-accent-green text-gray-900'
-                            : 'bg-gray-700 hover:bg-gray-600'
-                        }`}
-                      >
-                        {subtopic}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Tags */}
+              {/* ── Tags Searchable Multi-Select ── */}
               {filterOptions.tags.length > 0 && (
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">
-                    Filter by Tags
-                  </label>
-                  <div className="flex flex-wrap gap-2">
-                    {filterOptions.tags.map(tag => (
-                      <button
-                        key={tag}
-                        type="button"
-                        onClick={() => toggleSelection(tag, selectedTags, setSelectedTags)}
-                        className={`px-3 py-1 rounded-full text-sm ${
-                          selectedTags.includes(tag)
-                            ? 'bg-accent-green text-gray-900'
-                            : 'bg-gray-700 hover:bg-gray-600'
-                        }`}
-                      >
-                        #{tag}
-                      </button>
-                    ))}
+                <div ref={tagContainerRef}>
+                  <label className="block text-sm text-gray-400 mb-2">Tags</label>
+
+                  {/* Selected tag chips */}
+                  {selectedTags.length > 0 && (
+                    <div className="flex flex-wrap gap-1 mb-2">
+                      {selectedTags.map(tag => (
+                        <span
+                          key={tag}
+                          className="text-xs bg-dark-accent text-white px-2 py-1 rounded-full flex items-center gap-1"
+                        >
+                          #{tag}
+                          <button
+                            type="button"
+                            onClick={() => setSelectedTags(prev => prev.filter(t => t !== tag))}
+                            className="hover:text-red-400"
+                          >
+                            &times;
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Search input */}
+                  <div className="relative">
+                    <input
+                      ref={tagInputRef}
+                      type="text"
+                      value={tagSearch}
+                      onChange={e => {
+                        setTagSearch(e.target.value)
+                        setTagDropdownOpen(true)
+                      }}
+                      onFocus={() => setTagDropdownOpen(true)}
+                      placeholder="Search tags..."
+                      className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
+                    />
+
+                    {/* Dropdown */}
+                    {tagDropdownOpen && filteredTags.length > 0 && (
+                      <div className="absolute z-10 w-full mt-1 bg-dark-card border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-y-auto">
+                        {filteredTags.map(tag => (
+                          <button
+                            key={tag}
+                            type="button"
+                            onClick={() => {
+                              setSelectedTags(prev => [...prev, tag])
+                              setTagSearch('')
+                              tagInputRef.current?.focus()
+                            }}
+                            className="w-full text-left px-3 py-2 text-sm hover:bg-dark-accent/50 text-gray-300 hover:text-white"
+                          >
+                            #{tag}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
 
-              {/* States */}
+              {/* ── State Toggle Buttons ── */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
-                  Filter by State
-                </label>
+                <label className="block text-sm text-gray-400 mb-2">State</label>
                 <div className="flex flex-wrap gap-2">
                   {filterOptions.states.map(state => (
                     <button
                       key={state}
                       type="button"
                       onClick={() => toggleSelection(state, selectedStates, setSelectedStates)}
-                      className={`px-3 py-1 rounded-full text-sm ${
+                      className={`px-3 py-1 rounded-full text-sm transition-colors ${
                         selectedStates.includes(state)
                           ? 'bg-accent-green text-gray-900'
                           : 'bg-gray-700 hover:bg-gray-600'
@@ -386,24 +578,22 @@ export default function DecksPage() {
                 </div>
               </div>
 
-              {/* Importance */}
+              {/* ── Importance Toggle Buttons ── */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
-                  Filter by Importance
-                </label>
+                <label className="block text-sm text-gray-400 mb-2">Importance</label>
                 <div className="flex flex-wrap gap-2">
-                  {(filterOptions.importance || ['core', 'supporting']).map(imp => (
+                  {filterOptions.importance.map(imp => (
                     <button
                       key={imp}
                       type="button"
                       onClick={() => toggleSelection(imp, selectedImportance, setSelectedImportance)}
-                      className={`px-3 py-1 rounded-full text-sm ${
+                      className={`px-3 py-1 rounded-full text-sm transition-colors ${
                         selectedImportance.includes(imp)
                           ? 'bg-accent-green text-gray-900'
                           : 'bg-gray-700 hover:bg-gray-600'
                       }`}
                     >
-                      {imp === 'core' ? '⭐ Core' : 'Supporting'}
+                      {imp === 'core' ? 'Core' : 'Supporting'}
                     </button>
                   ))}
                 </div>
@@ -412,22 +602,89 @@ export default function DecksPage() {
                 </p>
               </div>
 
-              {/* Max cards */}
+              {/* ── Quality Toggle Buttons ── */}
+              {filterOptions.quality.length > 0 && (
+                <div>
+                  <label className="block text-sm text-gray-400 mb-2">Quality</label>
+                  <div className="flex flex-wrap gap-2">
+                    {filterOptions.quality.map(q => (
+                      <button
+                        key={q}
+                        type="button"
+                        onClick={() => toggleSelection(q, selectedQuality, setSelectedQuality)}
+                        className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                          selectedQuality.includes(q)
+                            ? 'bg-accent-green text-gray-900'
+                            : 'bg-gray-700 hover:bg-gray-600'
+                        }`}
+                      >
+                        {q}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* ── Difficulty Range ── */}
               <div>
-                <label className="block text-sm text-gray-400 mb-1">
-                  Max Cards (optional)
+                <label className="block text-sm text-gray-400 mb-2">
+                  Difficulty Range
+                  <span className="text-xs text-gray-500 ml-1">(1 = easy, 10 = hard, reviewed cards only)</span>
                 </label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="number"
+                    value={difficultyMin}
+                    onChange={e => setDifficultyMin(e.target.value ? parseFloat(e.target.value) : '')}
+                    placeholder="Min"
+                    min={1}
+                    max={10}
+                    step={0.5}
+                    className="w-24 px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
+                  />
+                  <span className="text-gray-500">to</span>
+                  <input
+                    type="number"
+                    value={difficultyMax}
+                    onChange={e => setDifficultyMax(e.target.value ? parseFloat(e.target.value) : '')}
+                    placeholder="Max"
+                    min={1}
+                    max={10}
+                    step={0.5}
+                    className="w-24 px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
+                  />
+                </div>
+              </div>
+
+              {/* ── Sort Order ── */}
+              <div>
+                <label className="block text-sm text-gray-400 mb-2">Sort Order</label>
+                <select
+                  value={sortOrder}
+                  onChange={e => setSortOrder(e.target.value)}
+                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
+                >
+                  <option value="due_date">Due Date (most overdue first)</option>
+                  <option value="difficulty">Most Difficult</option>
+                  <option value="lapses">Most Lapses</option>
+                  <option value="random">Random</option>
+                </select>
+              </div>
+
+              {/* ── Max Cards ── */}
+              <div>
+                <label className="block text-sm text-gray-400 mb-2">Max Cards (optional)</label>
                 <input
                   type="number"
                   value={maxCards}
                   onChange={e => setMaxCards(e.target.value ? parseInt(e.target.value) : '')}
                   placeholder="Leave empty for all matching cards"
                   min={1}
-                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none"
+                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
                 />
               </div>
 
-              {/* Buttons */}
+              {/* ── Buttons ── */}
               <div className="flex gap-3 pt-2">
                 <button
                   type="button"

--- a/supabase-migration-filtered-deck-filters.sql
+++ b/supabase-migration-filtered-deck-filters.sql
@@ -1,0 +1,9 @@
+-- Migration: Add new filter columns to filtered_decks
+-- Run this in Supabase SQL Editor
+
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS filter_subtopics TEXT[] DEFAULT '{}';
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS filter_importance TEXT[] DEFAULT '{}';
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS filter_quality TEXT[] DEFAULT '{}';
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS filter_difficulty_min REAL;
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS filter_difficulty_max REAL;
+ALTER TABLE filtered_decks ADD COLUMN IF NOT EXISTS sort_order TEXT DEFAULT 'due_date';


### PR DESCRIPTION
- Cards rated Again in filtered decks are re-appended to the queue so they keep appearing until the user gets them right
- Redesigned deck creation UI: accordion tree for topics/subtopics, searchable multi-select with chips for tags
- Added new filter options: quality (A/B/C), difficulty range (1-10), and sort order (due date, difficulty, lapses, random)
- Topics API now returns hierarchical topicTree for the accordion
- Added FSRS algorithm documentation to README