### PR TITLE
Deck management: cram defaults, live preview, learning counter fix

### DIFF
--- a/src/app/api/decks/[id]/next/route.ts
+++ b/src/app/api/decks/[id]/next/route.ts
@@ -270,7 +270,7 @@ async function getDeckCounts(
   let newAvailable = 0
 
   for (const card of cards || []) {
-    if ((card.state === 'learning' || card.state === 'relearning') && card.due_date && card.due_date <= now) {
+    if (card.state === 'learning' || card.state === 'relearning') {
       learningNow++
     } else if (card.state === 'review' && cardsIntroducedSet.has(card.card_id) && card.due_date && card.due_date <= now) {
       dueRemaining++

--- a/src/app/api/decks/route.ts
+++ b/src/app/api/decks/route.ts
@@ -69,7 +69,7 @@ export async function GET() {
       for (const id of cardPool) {
         const card = cardStateMap.get(id)
         if (!card) continue
-        if ((card.state === 'learning' || card.state === 'relearning') && card.due_date && card.due_date <= now) {
+        if (card.state === 'learning' || card.state === 'relearning') {
           learningNow++
         } else if (card.state === 'review' && introducedSet.has(id) && card.due_date && card.due_date <= now) {
           dueRemaining++
@@ -124,8 +124,8 @@ export async function POST(request: Request) {
       filterDifficultyMax,
       sortOrder = 'due_date',
       maxCards,
-      newPerSession = 20,
-      reviewPerSession = 200,
+      newPerSession = 200,
+      reviewPerSession = 999,
     } = body
 
     if (!name) {

--- a/src/app/decks/new/page.tsx
+++ b/src/app/decks/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 
@@ -48,12 +48,15 @@ export default function NewDeckPage() {
   const [difficultyMax, setDifficultyMax] = useState<number | ''>('')
   const [sortOrder, setSortOrder] = useState('due_date')
   const [maxCards, setMaxCards] = useState<number | ''>('')
-  const [newPerSession, setNewPerSession] = useState<number | ''>(20)
-  const [reviewPerSession, setReviewPerSession] = useState<number | ''>(200)
+  const [newPerSession, setNewPerSession] = useState<number | ''>(200)
+  const [reviewPerSession, setReviewPerSession] = useState<number | ''>(999)
   const [isCreating, setIsCreating] = useState(false)
 
   // Topic accordion state
   const [expandedTopics, setExpandedTopics] = useState<string[]>([])
+
+  // Advanced filters toggle
+  const [showAdvanced, setShowAdvanced] = useState(false)
 
   // Tag search state
   const [tagSearch, setTagSearch] = useState('')
@@ -95,6 +98,39 @@ export default function NewDeckPage() {
     fetchFilterOptions()
   }, [])
 
+  // Live card count preview from subtopicStats
+  const cardPreview = useMemo(() => {
+    const stats = filterOptions.subtopicStats
+    const allSubtopics = Object.values(filterOptions.topicTree).flat()
+
+    // If subtopics are selected, use those; otherwise sum all
+    const relevantSubtopics = selectedSubtopics.length > 0
+      ? selectedSubtopics
+      : allSubtopics
+
+    const agg = { total: 0, new: 0, due: 0, learning: 0 }
+    for (const st of relevantSubtopics) {
+      const s = stats[st]
+      if (s) {
+        agg.total += s.total
+        agg.new += s.new
+        agg.due += s.due
+        agg.learning += s.learning
+      }
+    }
+
+    const hasAdvancedFilters = selectedTags.length > 0 ||
+      selectedStates.length > 0 ||
+      selectedImportance.length > 0 ||
+      selectedQuality.length > 0 ||
+      difficultyMin !== '' ||
+      difficultyMax !== ''
+
+    return { ...agg, hasAdvancedFilters }
+  }, [filterOptions.subtopicStats, filterOptions.topicTree, selectedSubtopics,
+      selectedTags, selectedStates, selectedImportance, selectedQuality,
+      difficultyMin, difficultyMax])
+
   const handleCreateDeck = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!newDeckName.trim()) return
@@ -116,15 +152,15 @@ export default function NewDeckPage() {
           filterDifficultyMax: difficultyMax || null,
           sortOrder,
           maxCards: maxCards || null,
-          newPerSession: newPerSession || 20,
-          reviewPerSession: reviewPerSession || 200,
+          newPerSession: newPerSession || 200,
+          reviewPerSession: reviewPerSession || 999,
         }),
       })
 
       const data = await res.json()
 
       if (res.ok && data.deck) {
-        router.push('/')
+        router.push(`/decks/${data.deck.deck_id}`)
       } else {
         alert(data.error || 'Failed to create deck')
       }
@@ -340,145 +376,52 @@ export default function NewDeckPage() {
           </div>
         )}
 
-        {/* Tags */}
-        {filterOptions.tags.length > 0 && (
-          <div ref={tagContainerRef}>
-            <label className="block text-sm text-gray-400 mb-2">Tags</label>
-
-            {selectedTags.length > 0 && (
-              <div className="flex flex-wrap gap-1 mb-2">
-                {selectedTags.map(tag => (
-                  <span key={tag} className="tag-chip flex items-center gap-1">
-                    #{tag}
-                    <button
-                      type="button"
-                      onClick={() => setSelectedTags(prev => prev.filter(t => t !== tag))}
-                      className="hover:text-red-400"
-                    >
-                      ×
-                    </button>
-                  </span>
-                ))}
-              </div>
+        {/* Live card count preview */}
+        {cardPreview.total > 0 && (
+          <div className="flex items-center gap-3 px-4 py-3 rounded-lg bg-dark-accent/40 border border-gray-700/50">
+            <span className="text-lg font-semibold text-white">{cardPreview.total}</span>
+            <span className="text-sm text-gray-400">cards</span>
+            <span className="text-gray-600">·</span>
+            <span className="text-sm text-blue-400">{cardPreview.new} new</span>
+            <span className="text-sm text-green-400">{cardPreview.due} due</span>
+            {cardPreview.learning > 0 && (
+              <span className="text-sm text-orange-400">{cardPreview.learning} learning</span>
             )}
-
-            <div className="relative">
-              <input
-                ref={tagInputRef}
-                type="text"
-                value={tagSearch}
-                onChange={e => {
-                  setTagSearch(e.target.value)
-                  setTagDropdownOpen(true)
-                }}
-                onFocus={() => setTagDropdownOpen(true)}
-                placeholder="Search tags..."
-                className="create-deck-input"
-              />
-
-              {tagDropdownOpen && filteredTags.length > 0 && (
-                <div className="create-deck-dropdown">
-                  {filteredTags.map(tag => (
-                    <button
-                      key={tag}
-                      type="button"
-                      onClick={() => {
-                        setSelectedTags(prev => [...prev, tag])
-                        setTagSearch('')
-                        tagInputRef.current?.focus()
-                      }}
-                      className="create-deck-dropdown-item"
-                    >
-                      #{tag}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
+            {cardPreview.hasAdvancedFilters && (
+              <span className="text-xs text-gray-500 ml-auto">before filters</span>
+            )}
           </div>
         )}
 
-        {/* State */}
-        <div>
-          <label className="block text-sm text-gray-400 mb-2">State</label>
-          <div className="flex flex-wrap gap-2">
-            {filterOptions.states.map(state => (
-              <button
-                key={state}
-                type="button"
-                onClick={() => toggleSelection(state, selectedStates, setSelectedStates)}
-                className={`create-deck-toggle ${selectedStates.includes(state) ? 'create-deck-toggle--active' : ''}`}
-              >
-                {state}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Importance */}
-        <div>
-          <label className="block text-sm text-gray-400 mb-2">Importance</label>
-          <div className="flex flex-wrap gap-2">
-            {filterOptions.importance.map(imp => (
-              <button
-                key={imp}
-                type="button"
-                onClick={() => toggleSelection(imp, selectedImportance, setSelectedImportance)}
-                className={`create-deck-toggle ${selectedImportance.includes(imp) ? 'create-deck-toggle--active' : ''}`}
-              >
-                {imp === 'core' ? 'Core' : 'Supporting'}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Quality */}
-        {filterOptions.quality.length > 0 && (
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">Quality</label>
-            <div className="flex flex-wrap gap-2">
-              {filterOptions.quality.map(q => (
-                <button
-                  key={q}
-                  type="button"
-                  onClick={() => toggleSelection(q, selectedQuality, setSelectedQuality)}
-                  className={`create-deck-toggle ${selectedQuality.includes(q) ? 'create-deck-toggle--active' : ''}`}
-                >
-                  {q}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Difficulty Range */}
+        {/* Per-Session Limits */}
         <div>
           <label className="block text-sm text-gray-400 mb-2">
-            Difficulty Range
-            <span className="text-xs text-gray-600 ml-1">(1-10, reviewed cards only)</span>
+            Cards Per Session
+            <span className="text-xs text-gray-600 ml-1">(daily limits)</span>
           </label>
           <div className="flex items-center gap-3">
-            <input
-              type="number"
-              value={difficultyMin}
-              onChange={e => setDifficultyMin(e.target.value ? parseFloat(e.target.value) : '')}
-              placeholder="Min"
-              min={1}
-              max={10}
-              step={0.5}
-              className="create-deck-input w-24"
-            />
-            <span className="text-gray-500">to</span>
-            <input
-              type="number"
-              value={difficultyMax}
-              onChange={e => setDifficultyMax(e.target.value ? parseFloat(e.target.value) : '')}
-              placeholder="Max"
-              min={1}
-              max={10}
-              step={0.5}
-              className="create-deck-input w-24"
-            />
+            <div className="flex-1">
+              <label className="block text-xs text-gray-500 mb-1">New</label>
+              <input
+                type="number"
+                value={newPerSession}
+                onChange={e => setNewPerSession(e.target.value ? parseInt(e.target.value) : '')}
+                placeholder="200"
+                min={1}
+                className="create-deck-input"
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block text-xs text-gray-500 mb-1">Review</label>
+              <input
+                type="number"
+                value={reviewPerSession}
+                onChange={e => setReviewPerSession(e.target.value ? parseInt(e.target.value) : '')}
+                placeholder="999"
+                min={1}
+                className="create-deck-input"
+              />
+            </div>
           </div>
         </div>
 
@@ -497,50 +440,179 @@ export default function NewDeckPage() {
           </select>
         </div>
 
-        {/* Per-Session Limits */}
-        <div>
-          <label className="block text-sm text-gray-400 mb-2">
-            Cards Per Session
-            <span className="text-xs text-gray-600 ml-1">(daily limits)</span>
-          </label>
-          <div className="flex items-center gap-3">
-            <div className="flex-1">
-              <label className="block text-xs text-gray-500 mb-1">New</label>
-              <input
-                type="number"
-                value={newPerSession}
-                onChange={e => setNewPerSession(e.target.value ? parseInt(e.target.value) : '')}
-                placeholder="20"
-                min={1}
-                className="create-deck-input"
-              />
+        {/* Advanced Filters Toggle */}
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="text-sm text-gray-500 hover:text-gray-300 transition-colors flex items-center gap-1.5"
+        >
+          <span className="text-xs">{showAdvanced ? '▼' : '▶'}</span>
+          Advanced Filters
+          {(selectedTags.length > 0 || selectedStates.length > 0 ||
+            selectedImportance.length > 0 || selectedQuality.length > 0 ||
+            difficultyMin !== '' || difficultyMax !== '' || maxCards !== '') && (
+            <span className="text-xs text-accent-green ml-1">(active)</span>
+          )}
+        </button>
+
+        {showAdvanced && (
+          <div className="space-y-5 pl-3 border-l-2 border-gray-700/50">
+            {/* Tags */}
+            {filterOptions.tags.length > 0 && (
+              <div ref={tagContainerRef}>
+                <label className="block text-sm text-gray-400 mb-2">Tags</label>
+
+                {selectedTags.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mb-2">
+                    {selectedTags.map(tag => (
+                      <span key={tag} className="tag-chip flex items-center gap-1">
+                        #{tag}
+                        <button
+                          type="button"
+                          onClick={() => setSelectedTags(prev => prev.filter(t => t !== tag))}
+                          className="hover:text-red-400"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                )}
+
+                <div className="relative">
+                  <input
+                    ref={tagInputRef}
+                    type="text"
+                    value={tagSearch}
+                    onChange={e => {
+                      setTagSearch(e.target.value)
+                      setTagDropdownOpen(true)
+                    }}
+                    onFocus={() => setTagDropdownOpen(true)}
+                    placeholder="Search tags..."
+                    className="create-deck-input"
+                  />
+
+                  {tagDropdownOpen && filteredTags.length > 0 && (
+                    <div className="create-deck-dropdown">
+                      {filteredTags.map(tag => (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => {
+                            setSelectedTags(prev => [...prev, tag])
+                            setTagSearch('')
+                            tagInputRef.current?.focus()
+                          }}
+                          className="create-deck-dropdown-item"
+                        >
+                          #{tag}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* State */}
+            <div>
+              <label className="block text-sm text-gray-400 mb-2">State</label>
+              <div className="flex flex-wrap gap-2">
+                {filterOptions.states.map(state => (
+                  <button
+                    key={state}
+                    type="button"
+                    onClick={() => toggleSelection(state, selectedStates, setSelectedStates)}
+                    className={`create-deck-toggle ${selectedStates.includes(state) ? 'create-deck-toggle--active' : ''}`}
+                  >
+                    {state}
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="flex-1">
-              <label className="block text-xs text-gray-500 mb-1">Review</label>
+
+            {/* Importance */}
+            <div>
+              <label className="block text-sm text-gray-400 mb-2">Importance</label>
+              <div className="flex flex-wrap gap-2">
+                {filterOptions.importance.map(imp => (
+                  <button
+                    key={imp}
+                    type="button"
+                    onClick={() => toggleSelection(imp, selectedImportance, setSelectedImportance)}
+                    className={`create-deck-toggle ${selectedImportance.includes(imp) ? 'create-deck-toggle--active' : ''}`}
+                  >
+                    {imp === 'core' ? 'Core' : 'Supporting'}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Quality */}
+            {filterOptions.quality.length > 0 && (
+              <div>
+                <label className="block text-sm text-gray-400 mb-2">Quality</label>
+                <div className="flex flex-wrap gap-2">
+                  {filterOptions.quality.map(q => (
+                    <button
+                      key={q}
+                      type="button"
+                      onClick={() => toggleSelection(q, selectedQuality, setSelectedQuality)}
+                      className={`create-deck-toggle ${selectedQuality.includes(q) ? 'create-deck-toggle--active' : ''}`}
+                    >
+                      {q}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Difficulty Range */}
+            <div>
+              <label className="block text-sm text-gray-400 mb-2">
+                Difficulty Range
+                <span className="text-xs text-gray-600 ml-1">(1-10, reviewed cards only)</span>
+              </label>
+              <div className="flex items-center gap-3">
+                <input
+                  type="number"
+                  value={difficultyMin}
+                  onChange={e => setDifficultyMin(e.target.value ? parseFloat(e.target.value) : '')}
+                  placeholder="Min"
+                  min={1}
+                  max={10}
+                  step={0.5}
+                  className="create-deck-input w-24"
+                />
+                <span className="text-gray-500">to</span>
+                <input
+                  type="number"
+                  value={difficultyMax}
+                  onChange={e => setDifficultyMax(e.target.value ? parseFloat(e.target.value) : '')}
+                  placeholder="Max"
+                  min={1}
+                  max={10}
+                  step={0.5}
+                  className="create-deck-input w-24"
+                />
+              </div>
+            </div>
+
+            {/* Max Cards */}
+            <div>
+              <label className="block text-sm text-gray-400 mb-2">Max Cards in Pool</label>
               <input
                 type="number"
-                value={reviewPerSession}
-                onChange={e => setReviewPerSession(e.target.value ? parseInt(e.target.value) : '')}
-                placeholder="200"
+                value={maxCards}
+                onChange={e => setMaxCards(e.target.value ? parseInt(e.target.value) : '')}
+                placeholder="All matching cards"
                 min={1}
                 className="create-deck-input"
               />
             </div>
           </div>
-        </div>
-
-        {/* Max Cards */}
-        <div>
-          <label className="block text-sm text-gray-400 mb-2">Max Cards in Pool (optional)</label>
-          <input
-            type="number"
-            value={maxCards}
-            onChange={e => setMaxCards(e.target.value ? parseInt(e.target.value) : '')}
-            placeholder="All matching cards"
-            min={1}
-            className="create-deck-input"
-          />
-        </div>
+        )}
 
         {/* Buttons */}
         <div className="flex gap-3 pt-2 pb-8">

--- a/src/app/decks/page.tsx
+++ b/src/app/decks/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect } from 'react'
 import Link from 'next/link'
 
 interface Deck {
@@ -17,163 +17,26 @@ interface Deck {
   newRemaining: number
   dueRemaining: number
   learningNow: number
-  completed: boolean
-}
-
-interface FilterOptions {
-  topicTree: Record<string, string[]>
-  topics: string[]
-  subtopics: string[]
-  tags: string[]
-  quality: string[]
-  states: string[]
-  importance: string[]
 }
 
 export default function DecksPage() {
   const [decks, setDecks] = useState<Deck[]>([])
-  const [filterOptions, setFilterOptions] = useState<FilterOptions>({
-    topicTree: {},
-    topics: [],
-    subtopics: [],
-    tags: [],
-    quality: [],
-    states: [],
-    importance: [],
-  })
   const [isLoading, setIsLoading] = useState(true)
-  const [showCreateModal, setShowCreateModal] = useState(false)
 
-  // Form state
-  const [newDeckName, setNewDeckName] = useState('')
-  const [selectedTopics, setSelectedTopics] = useState<string[]>([])
-  const [selectedSubtopics, setSelectedSubtopics] = useState<string[]>([])
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-  const [selectedStates, setSelectedStates] = useState<string[]>([])
-  const [selectedImportance, setSelectedImportance] = useState<string[]>([])
-  const [selectedQuality, setSelectedQuality] = useState<string[]>([])
-  const [difficultyMin, setDifficultyMin] = useState<number | ''>('')
-  const [difficultyMax, setDifficultyMax] = useState<number | ''>('')
-  const [sortOrder, setSortOrder] = useState('due_date')
-  const [maxCards, setMaxCards] = useState<number | ''>('')
-  const [newPerSession, setNewPerSession] = useState<number | ''>(20)
-  const [reviewPerSession, setReviewPerSession] = useState<number | ''>(200)
-  const [isCreating, setIsCreating] = useState(false)
-
-  // Topic accordion state
-  const [expandedTopics, setExpandedTopics] = useState<string[]>([])
-
-  // Tag search state
-  const [tagSearch, setTagSearch] = useState('')
-  const [tagDropdownOpen, setTagDropdownOpen] = useState(false)
-  const tagInputRef = useRef<HTMLInputElement>(null)
-  const tagContainerRef = useRef<HTMLDivElement>(null)
-
-  // Close tag dropdown when clicking outside
   useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (tagContainerRef.current && !tagContainerRef.current.contains(e.target as Node)) {
-        setTagDropdownOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
-
-  // Fetch decks and filter options
-  useEffect(() => {
-    async function fetchData() {
-      setIsLoading(true)
+    async function fetchDecks() {
       try {
-        const [decksRes, topicsRes] = await Promise.all([
-          fetch('/api/decks'),
-          fetch('/api/topics'),
-        ])
-
-        const decksData = await decksRes.json()
-        const topicsData = await topicsRes.json()
-
-        setDecks(decksData.decks || [])
-        setFilterOptions({
-          topicTree: topicsData.topicTree || {},
-          topics: topicsData.topics || [],
-          subtopics: topicsData.subtopics || [],
-          tags: topicsData.tags || [],
-          quality: topicsData.quality || [],
-          states: topicsData.states || [],
-          importance: topicsData.importance || [],
-        })
+        const res = await fetch('/api/decks')
+        const data = await res.json()
+        setDecks(data.decks || [])
       } catch (err) {
-        console.error('Error fetching data:', err)
+        console.error('Error fetching decks:', err)
       } finally {
         setIsLoading(false)
       }
     }
-
-    fetchData()
+    fetchDecks()
   }, [])
-
-  // Create deck
-  const handleCreateDeck = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!newDeckName.trim()) return
-
-    setIsCreating(true)
-    try {
-      const res = await fetch('/api/decks', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: newDeckName,
-          filterTopics: selectedTopics,
-          filterSubtopics: selectedSubtopics,
-          filterTags: selectedTags,
-          filterStates: selectedStates,
-          filterImportance: selectedImportance,
-          filterQuality: selectedQuality,
-          filterDifficultyMin: difficultyMin || null,
-          filterDifficultyMax: difficultyMax || null,
-          sortOrder,
-          maxCards: maxCards || null,
-          newPerSession: newPerSession || 20,
-          reviewPerSession: reviewPerSession || 200,
-        }),
-      })
-
-      const data = await res.json()
-
-      if (res.ok && data.deck) {
-        setDecks([data.deck, ...decks])
-        setShowCreateModal(false)
-        resetForm()
-      } else {
-        alert(data.error || 'Failed to create deck')
-      }
-    } catch (err) {
-      console.error('Error creating deck:', err)
-      alert('Failed to create deck')
-    } finally {
-      setIsCreating(false)
-    }
-  }
-
-  const resetForm = () => {
-    setNewDeckName('')
-    setSelectedTopics([])
-    setSelectedSubtopics([])
-    setSelectedTags([])
-    setSelectedStates([])
-    setSelectedImportance([])
-    setSelectedQuality([])
-    setDifficultyMin('')
-    setDifficultyMax('')
-    setSortOrder('due_date')
-    setMaxCards('')
-    setNewPerSession(20)
-    setReviewPerSession(200)
-    setExpandedTopics([])
-    setTagSearch('')
-  }
 
   const handleDeleteDeck = async (deckId: string) => {
     if (!confirm('Delete this deck?')) return
@@ -184,88 +47,6 @@ export default function DecksPage() {
       console.error('Error deleting deck:', err)
     }
   }
-
-  const toggleSelection = (
-    value: string,
-    selected: string[],
-    setSelected: React.Dispatch<React.SetStateAction<string[]>>
-  ) => {
-    if (selected.includes(value)) {
-      setSelected(selected.filter(v => v !== value))
-    } else {
-      setSelected([...selected, value])
-    }
-  }
-
-  // Topic accordion helpers
-  const toggleTopicExpanded = (topic: string) => {
-    setExpandedTopics(prev =>
-      prev.includes(topic)
-        ? prev.filter(t => t !== topic)
-        : [...prev, topic]
-    )
-  }
-
-  const isTopicFullySelected = (topic: string) => {
-    const subtopics = filterOptions.topicTree[topic] || []
-    return subtopics.length > 0 && subtopics.every(st => selectedSubtopics.includes(st))
-  }
-
-  const isTopicPartiallySelected = (topic: string) => {
-    const subtopics = filterOptions.topicTree[topic] || []
-    const someSelected = subtopics.some(st => selectedSubtopics.includes(st))
-    return someSelected && !isTopicFullySelected(topic)
-  }
-
-  const toggleTopicSelection = (topic: string) => {
-    const subtopics = filterOptions.topicTree[topic] || []
-
-    if (isTopicFullySelected(topic)) {
-      // Deselect topic and all its subtopics
-      setSelectedTopics(prev => prev.filter(t => t !== topic))
-      setSelectedSubtopics(prev => prev.filter(st => !subtopics.includes(st)))
-    } else {
-      // Select topic and all its subtopics
-      if (!selectedTopics.includes(topic)) {
-        setSelectedTopics(prev => [...prev, topic])
-      }
-      setSelectedSubtopics(prev => {
-        const newSubs = [...prev]
-        for (const st of subtopics) {
-          if (!newSubs.includes(st)) newSubs.push(st)
-        }
-        return newSubs
-      })
-    }
-  }
-
-  const toggleSubtopicSelection = (topic: string, subtopic: string) => {
-    const subtopics = filterOptions.topicTree[topic] || []
-
-    if (selectedSubtopics.includes(subtopic)) {
-      // Deselect subtopic
-      const newSubs = selectedSubtopics.filter(st => st !== subtopic)
-      setSelectedSubtopics(newSubs)
-      // If no subtopics of this topic remain, deselect the topic too
-      const remainingForTopic = newSubs.filter(st => subtopics.includes(st))
-      if (remainingForTopic.length === 0) {
-        setSelectedTopics(prev => prev.filter(t => t !== topic))
-      }
-    } else {
-      // Select subtopic and ensure parent topic is selected
-      setSelectedSubtopics(prev => [...prev, subtopic])
-      if (!selectedTopics.includes(topic)) {
-        setSelectedTopics(prev => [...prev, topic])
-      }
-    }
-  }
-
-  // Tag search helpers
-  const filteredTags = filterOptions.tags.filter(
-    tag =>
-      !selectedTags.includes(tag) &&
-      tag.toLowerCase().includes(tagSearch.toLowerCase())
-  )
 
   if (isLoading) {
     return (
@@ -285,12 +66,12 @@ export default function DecksPage() {
           </Link>
           <h1 className="text-2xl font-bold mt-2">Filtered Decks</h1>
         </div>
-        <button
-          onClick={() => setShowCreateModal(true)}
+        <Link
+          href="/decks/new"
           className="px-4 py-2 bg-accent-green hover:opacity-90 rounded-lg text-gray-900 font-medium"
         >
           + New Deck
-        </button>
+        </Link>
       </div>
 
       {/* Deck list */}
@@ -309,6 +90,9 @@ export default function DecksPage() {
                   <div className="flex gap-3 text-sm text-gray-400">
                     <span className="text-blue-400">{deck.newRemaining ?? 0} new</span>
                     <span className="text-green-400">{deck.dueRemaining ?? 0} due</span>
+                    {deck.learningNow > 0 && (
+                      <span className="text-orange-400">{deck.learningNow} learning</span>
+                    )}
                     <span>{deck.totalCards} total</span>
                   </div>
                 </div>
@@ -327,8 +111,6 @@ export default function DecksPage() {
                   </button>
                 </div>
               </div>
-
-              {/* Stats row replaces progress bar */}
 
               {/* Filter tags display */}
               {(
@@ -368,360 +150,6 @@ export default function DecksPage() {
               )}
             </div>
           ))}
-        </div>
-      )}
-
-      {/* Create Modal */}
-      {showCreateModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-dark-card rounded-xl p-6 max-w-lg w-full max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-bold mb-4">Create Filtered Deck</h2>
-
-            <form onSubmit={handleCreateDeck} className="space-y-5">
-              {/* Deck Name */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Deck Name</label>
-                <input
-                  type="text"
-                  value={newDeckName}
-                  onChange={e => setNewDeckName(e.target.value)}
-                  placeholder="e.g., Cytology Review"
-                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none"
-                  required
-                />
-              </div>
-
-              {/* ── Topics & Subtopics Accordion ── */}
-              {Object.keys(filterOptions.topicTree).length > 0 && (
-                <div>
-                  <label className="block text-sm text-gray-400 mb-2">Topics &amp; Subtopics</label>
-                  <div className="border border-gray-600 rounded-lg overflow-hidden">
-                    {Object.entries(filterOptions.topicTree).map(([topic, subtopics]) => (
-                      <div key={topic} className="border-b border-gray-700 last:border-b-0">
-                        {/* Topic row */}
-                        <div className="flex items-center gap-2 px-3 py-2 hover:bg-dark-accent/30">
-                          {/* Expand/collapse button */}
-                          <button
-                            type="button"
-                            onClick={() => toggleTopicExpanded(topic)}
-                            className="text-gray-400 hover:text-white w-5 text-center flex-shrink-0"
-                          >
-                            {expandedTopics.includes(topic) ? '\u25BC' : '\u25B6'}
-                          </button>
-
-                          {/* Topic checkbox */}
-                          <label className="flex items-center gap-2 flex-1 cursor-pointer select-none">
-                            <input
-                              type="checkbox"
-                              checked={isTopicFullySelected(topic)}
-                              ref={el => {
-                                if (el) el.indeterminate = isTopicPartiallySelected(topic)
-                              }}
-                              onChange={() => toggleTopicSelection(topic)}
-                              className="w-4 h-4 rounded accent-[#8AC926]"
-                            />
-                            <span className="font-medium">{topic}</span>
-                            <span className="text-xs text-gray-500">
-                              ({subtopics.length} subtopic{subtopics.length !== 1 ? 's' : ''})
-                            </span>
-                          </label>
-                        </div>
-
-                        {/* Subtopics (expanded) */}
-                        {expandedTopics.includes(topic) && subtopics.length > 0 && (
-                          <div className="bg-dark-bg/50 pl-10 pr-3 py-1">
-                            {subtopics.map(subtopic => (
-                              <label
-                                key={subtopic}
-                                className="flex items-center gap-2 py-1.5 cursor-pointer select-none hover:text-white text-gray-300"
-                              >
-                                <input
-                                  type="checkbox"
-                                  checked={selectedSubtopics.includes(subtopic)}
-                                  onChange={() => toggleSubtopicSelection(topic, subtopic)}
-                                  className="w-4 h-4 rounded accent-[#8AC926]"
-                                />
-                                <span className="text-sm">{subtopic}</span>
-                              </label>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
-                  {/* Selected summary */}
-                  {selectedSubtopics.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mt-2">
-                      {selectedSubtopics.map(st => (
-                        <span
-                          key={st}
-                          className="text-xs bg-accent-green/20 text-accent-green px-2 py-0.5 rounded-full flex items-center gap-1"
-                        >
-                          {st}
-                          <button
-                            type="button"
-                            onClick={() => {
-                              // Find parent topic
-                              const parentTopic = Object.entries(filterOptions.topicTree)
-                                .find(([, subs]) => subs.includes(st))?.[0]
-                              if (parentTopic) toggleSubtopicSelection(parentTopic, st)
-                            }}
-                            className="hover:text-white"
-                          >
-                            &times;
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* ── Tags Searchable Multi-Select ── */}
-              {filterOptions.tags.length > 0 && (
-                <div ref={tagContainerRef}>
-                  <label className="block text-sm text-gray-400 mb-2">Tags</label>
-
-                  {/* Selected tag chips */}
-                  {selectedTags.length > 0 && (
-                    <div className="flex flex-wrap gap-1 mb-2">
-                      {selectedTags.map(tag => (
-                        <span
-                          key={tag}
-                          className="text-xs bg-dark-accent text-white px-2 py-1 rounded-full flex items-center gap-1"
-                        >
-                          #{tag}
-                          <button
-                            type="button"
-                            onClick={() => setSelectedTags(prev => prev.filter(t => t !== tag))}
-                            className="hover:text-red-400"
-                          >
-                            &times;
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-
-                  {/* Search input */}
-                  <div className="relative">
-                    <input
-                      ref={tagInputRef}
-                      type="text"
-                      value={tagSearch}
-                      onChange={e => {
-                        setTagSearch(e.target.value)
-                        setTagDropdownOpen(true)
-                      }}
-                      onFocus={() => setTagDropdownOpen(true)}
-                      placeholder="Search tags..."
-                      className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                    />
-
-                    {/* Dropdown */}
-                    {tagDropdownOpen && filteredTags.length > 0 && (
-                      <div className="absolute z-10 w-full mt-1 bg-dark-card border border-gray-600 rounded-lg shadow-lg max-h-40 overflow-y-auto">
-                        {filteredTags.map(tag => (
-                          <button
-                            key={tag}
-                            type="button"
-                            onClick={() => {
-                              setSelectedTags(prev => [...prev, tag])
-                              setTagSearch('')
-                              tagInputRef.current?.focus()
-                            }}
-                            className="w-full text-left px-3 py-2 text-sm hover:bg-dark-accent/50 text-gray-300 hover:text-white"
-                          >
-                            #{tag}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* ── State Toggle Buttons ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">State</label>
-                <div className="flex flex-wrap gap-2">
-                  {filterOptions.states.map(state => (
-                    <button
-                      key={state}
-                      type="button"
-                      onClick={() => toggleSelection(state, selectedStates, setSelectedStates)}
-                      className={`px-3 py-1 rounded-full text-sm transition-colors ${
-                        selectedStates.includes(state)
-                          ? 'bg-accent-green text-gray-900'
-                          : 'bg-gray-700 hover:bg-gray-600'
-                      }`}
-                    >
-                      {state}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* ── Importance Toggle Buttons ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">Importance</label>
-                <div className="flex flex-wrap gap-2">
-                  {filterOptions.importance.map(imp => (
-                    <button
-                      key={imp}
-                      type="button"
-                      onClick={() => toggleSelection(imp, selectedImportance, setSelectedImportance)}
-                      className={`px-3 py-1 rounded-full text-sm transition-colors ${
-                        selectedImportance.includes(imp)
-                          ? 'bg-accent-green text-gray-900'
-                          : 'bg-gray-700 hover:bg-gray-600'
-                      }`}
-                    >
-                      {imp === 'core' ? 'Core' : 'Supporting'}
-                    </button>
-                  ))}
-                </div>
-                <p className="text-xs text-gray-500 mt-1">
-                  Core = must-know concepts, Supporting = reinforcement
-                </p>
-              </div>
-
-              {/* ── Quality Toggle Buttons ── */}
-              {filterOptions.quality.length > 0 && (
-                <div>
-                  <label className="block text-sm text-gray-400 mb-2">Quality</label>
-                  <div className="flex flex-wrap gap-2">
-                    {filterOptions.quality.map(q => (
-                      <button
-                        key={q}
-                        type="button"
-                        onClick={() => toggleSelection(q, selectedQuality, setSelectedQuality)}
-                        className={`px-3 py-1 rounded-full text-sm transition-colors ${
-                          selectedQuality.includes(q)
-                            ? 'bg-accent-green text-gray-900'
-                            : 'bg-gray-700 hover:bg-gray-600'
-                        }`}
-                      >
-                        {q}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* ── Difficulty Range ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">
-                  Difficulty Range
-                  <span className="text-xs text-gray-500 ml-1">(1 = easy, 10 = hard, reviewed cards only)</span>
-                </label>
-                <div className="flex items-center gap-3">
-                  <input
-                    type="number"
-                    value={difficultyMin}
-                    onChange={e => setDifficultyMin(e.target.value ? parseFloat(e.target.value) : '')}
-                    placeholder="Min"
-                    min={1}
-                    max={10}
-                    step={0.5}
-                    className="w-24 px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                  />
-                  <span className="text-gray-500">to</span>
-                  <input
-                    type="number"
-                    value={difficultyMax}
-                    onChange={e => setDifficultyMax(e.target.value ? parseFloat(e.target.value) : '')}
-                    placeholder="Max"
-                    min={1}
-                    max={10}
-                    step={0.5}
-                    className="w-24 px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                  />
-                </div>
-              </div>
-
-              {/* ── Sort Order ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">Sort Order</label>
-                <select
-                  value={sortOrder}
-                  onChange={e => setSortOrder(e.target.value)}
-                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                >
-                  <option value="due_date">Due Date (most overdue first)</option>
-                  <option value="difficulty">Most Difficult</option>
-                  <option value="lapses">Most Lapses</option>
-                  <option value="random">Random</option>
-                </select>
-              </div>
-
-              {/* ── Per-Session Limits ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">
-                  Cards Per Session
-                  <span className="text-xs text-gray-500 ml-1">(daily limits)</span>
-                </label>
-                <div className="flex items-center gap-3">
-                  <div className="flex-1">
-                    <label className="block text-xs text-gray-500 mb-1">New</label>
-                    <input
-                      type="number"
-                      value={newPerSession}
-                      onChange={e => setNewPerSession(e.target.value ? parseInt(e.target.value) : '')}
-                      placeholder="20"
-                      min={1}
-                      className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <label className="block text-xs text-gray-500 mb-1">Review</label>
-                    <input
-                      type="number"
-                      value={reviewPerSession}
-                      onChange={e => setReviewPerSession(e.target.value ? parseInt(e.target.value) : '')}
-                      placeholder="200"
-                      min={1}
-                      className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                    />
-                  </div>
-                </div>
-              </div>
-
-              {/* ── Max Cards in Pool ── */}
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">Max Cards in Pool (optional)</label>
-                <input
-                  type="number"
-                  value={maxCards}
-                  onChange={e => setMaxCards(e.target.value ? parseInt(e.target.value) : '')}
-                  placeholder="Leave empty for all matching cards"
-                  min={1}
-                  className="w-full px-3 py-2 bg-dark-bg rounded-lg border border-gray-600 focus:border-accent-green focus:outline-none text-sm"
-                />
-              </div>
-
-              {/* ── Buttons ── */}
-              <div className="flex gap-3 pt-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowCreateModal(false)
-                    resetForm()
-                  }}
-                  className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded-lg"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={isCreating || !newDeckName.trim()}
-                  className="flex-1 px-4 py-2 bg-accent-green hover:opacity-90 rounded-lg disabled:opacity-50 text-gray-900 font-medium"
-                >
-                  {isCreating ? 'Creating...' : 'Create Deck'}
-                </button>
-              </div>
-            </form>
-          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Fix learning counter to count all learning/relearning cards (not just due), so "Again" immediately reflects in the counter instead of disappearing for 1 min
- Change session defaults to 200 new / 999 review to match cram study workflow
- Add live card count preview on deck creation that updates as topics are selected
- Collapse rarely-used filters behind "Advanced Filters" toggle
- Redirect to review page after deck creation instead of home
- Remove duplicate 570-line creation modal from `/decks` page, consolidate to `/decks/new`

## Test plan
- [ ] Create a deck → should redirect to review page (not home)
- [ ] Verify default session limits show 200 new / 999 review
- [ ] Select/deselect topics on creation page → card count preview updates live
- [ ] Start a review session, hit "Again" → learning counter should immediately show 1
- [ ] Open Advanced Filters → tags, state, importance, quality, difficulty, max cards visible
- [ ] Visit `/decks` → clean listing page with link to `/decks/new` (no modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)